### PR TITLE
Fix the problem #6 that get the true size for image

### DIFF
--- a/ng-jcrop.js
+++ b/ng-jcrop.js
@@ -193,7 +193,7 @@
          */
         $scope.onMainImageLoad = function(){
             $scope.mainImg.off('load', $scope.onMainImageLoad);
-            $scope.updateCurrentSizes($scope.mainImg[0]);
+            $scope.updateCurrentSizes($('<img>').attr('src', $scope.mainImg[0].src)[0]);
 
             var config = angular.extend({
                 onChange: $scope.showPreview,


### PR DESCRIPTION
Hi, @andrefarzat. I think I found the reason of the problem which we talk about. The image will wrapped by a container when it was loaded, and the largest size of it is the size of the container, so we will get a wrong size if the size of image is larger than the container.

And in the pull request, I create a image in memory and set the `src` for it in the `onMainImageLoad` function, then send it as a param for the `updateCurrentSize` function, then I can get the real size of the image and the real coords. How do you think this? :P
