### PR TITLE
Update ng-jcrop.js

### DIFF
--- a/ng-jcrop.js
+++ b/ng-jcrop.js
@@ -166,8 +166,8 @@
         $scope.getShrinkRatio = function(){
             var img = $('<img>').attr('src', $scope.mainImg[0].src)[0];
 
-            var widthShrinkRatio = img.width / ngJcropConfig.jcrop.maxWidth,
-                heightShrinkRatio = img.height / ngJcropConfig.jcrop.maxHeight,
+            var widthShrinkRatio = img.width > ngJcropConfig.maxWidth ? img.width / ngJcropConfig.jcrop.maxWidth : 1,
+                heightShrinkRatio = img.height > ngJcropConfig.maxHeight ? img.height / ngJcropConfig.jcrop.maxHeight : 1,
                 widthConstraining = img.width > ngJcropConfig.jcrop.maxWidth && widthShrinkRatio > heightShrinkRatio;
 
             if(widthConstraining) {

--- a/ng-jcrop.js
+++ b/ng-jcrop.js
@@ -166,8 +166,8 @@
         $scope.getShrinkRatio = function(){
             var img = $('<img>').attr('src', $scope.mainImg[0].src)[0];
 
-            var widthShrinkRatio = img.width > ngJcropConfig.maxWidth ? img.width / ngJcropConfig.jcrop.maxWidth : 1,
-                heightShrinkRatio = img.height > ngJcropConfig.maxHeight ? img.height / ngJcropConfig.jcrop.maxHeight : 1,
+            var widthShrinkRatio = img.width > ngJcropConfig.jcrop.maxWidth ? img.width / ngJcropConfig.jcrop.maxWidth : 1,
+                heightShrinkRatio = img.height > ngJcropConfig.jcrop.maxHeight ? img.height / ngJcropConfig.jcrop.maxHeight : 1,
                 widthConstraining = img.width > ngJcropConfig.jcrop.maxWidth && widthShrinkRatio > heightShrinkRatio;
 
             if(widthConstraining) {


### PR DESCRIPTION
Before this commit, if the image dimensions were smaller than the max dimensions, then it would return a shrunken down selection. The jcrop preview selection would be correct, but the saved coordinates would be smaller than the actual highlighted selection.

This commit checks if the image is smaller than the max, than do a 1:1 selection:coords comparison.