### PR TITLE
Fix for the wrong coordinates bug when having an image smaller then minwidth or minheight by single axis

### DIFF
--- a/ng-jcrop.js
+++ b/ng-jcrop.js
@@ -213,7 +213,7 @@
         $scope.getShrinkRatio = function(){
             var img = $('<img>').attr('src', $scope.mainImg[0].src)[0];
 
-            if(ngJcropConfig.jcrop.maxWidth > img.width || ngJcropConfig.jcrop.maxHeight > img.height){
+            if(ngJcropConfig.jcrop.maxWidth > img.width && ngJcropConfig.jcrop.maxHeight > img.height){
                 return 1;
             }
 


### PR DESCRIPTION
Please read this issue with comments on a bug: [issue #44 ]( https://github.com/andrefarzat/ng-jcrop/issues/44)