### PR TITLE
Fix config validation in ng-jcrop input directive

### DIFF
--- a/ng-jcrop.js
+++ b/ng-jcrop.js
@@ -120,6 +120,10 @@
         var configName = $scope.ngJcropInput || 'default';
         ngJcropConfig  = ngJcropConfig[configName];
 
+        if (!ngJcropConfig) {
+            throw new Error('Unknown "' + configName + '" config name');
+        }
+
         if ($element[0].type === 'file') {
             // Treating the input[type="file"]
             $scope.onFileReaderLoad = function(ev){

--- a/test/ng-jcrop_test.js
+++ b/test/ng-jcrop_test.js
@@ -401,6 +401,15 @@ describe('ng-jcrop', function(){
             el.trigger('change');
             expect(scope.setUrl).toHaveBeenCalledWith('/base/test/13x13.png');
         }));
+
+        it('should throw an error if config name is unknown', inject(function($rootScope, $compile){
+            var scope = $rootScope.$new();
+            var el = $compile('<input type="file" ng-jcrop-input="unknown" />')(scope);
+
+            expect(function(){
+                getController({$scope: scope, $element: el});
+            }).toThrow(new Error('Unknown "unknown" config name'));
+        }));
     });
 
 });


### PR DESCRIPTION
## Summary
- validate configuration name for `ng-jcrop-input`
- add regression test

## Testing
- `npm test` *(fails: bower not found)*

------
https://chatgpt.com/codex/tasks/task_e_684334c3ebf88332ad899ab436b76aac